### PR TITLE
Fix incorrect link to install script in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Invoke-WebRequest -UseBasicParsing "https://raw.githubusercontent.com/nimsandu/s
 ### Linux/macOS (Bash)
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/nimsandu/spicetify-bloom/install.sh | sh
+curl -fsSL https://raw.githubusercontent.com/nimsandu/spicetify-bloom/main/install.sh | sh
 ```
 
 ### OR DOWNLOAD Release script (powershell or shell) and run on your machine


### PR DESCRIPTION
Small fix. The link to the Linux install script in the README file was missing the branch name, resulting in a 400 error when trying to use it.