### PR TITLE
fix: hide "Liked Songs" label

### DIFF
--- a/user.css
+++ b/user.css
@@ -453,7 +453,7 @@ h3,
 
 .main-likedSongsButton-likedSongsIcon,
 .main-yourEpisodesButton-yourEpisodesIcon,
-.main-collectionLinkButton-collectionLinkText {
+.main-collectionLinkButton-collectionLinkButton .ot6VAZq1Xfbw2Vh8Qt_A {
   display: none !important;
 }
 


### PR DESCRIPTION
![Screenshot_7](https://user-images.githubusercontent.com/51394649/179181670-b8d392f4-b232-42cd-939b-42ad9d0ff277.png)
I noticed this and I think it doesn't suppose to show the label thingy.

![Screenshot_8](https://user-images.githubusercontent.com/51394649/179181702-d83cb97d-1fe0-431e-9ad8-3c51862123d8.png)
I fixed it with one simple class change.