### PR TITLE
fix: playlist title cutoff

### DIFF
--- a/user.css
+++ b/user.css
@@ -210,6 +210,7 @@ html {
 .main-entityHeader-title {
   font-size: unset;
   font-weight: 500;
+  display: contents;
 }
 
 h1,


### PR DESCRIPTION
Took me a while to figure it out, but I managed to make a fix to the playlist title being cutoff from the bottom. (see screenshots below)
![Screenshot_13](https://user-images.githubusercontent.com/51394649/179648990-f0938006-1910-4947-9577-b841ce23260c.png)
![Screenshot_14](https://user-images.githubusercontent.com/51394649/179648993-e15818f2-3763-4a2d-9340-82d3183aefa7.png)

