### PR TITLE
feat: add hover/active states to skip forward/backward buttons

### DIFF
--- a/user.css
+++ b/user.css
@@ -1676,6 +1676,19 @@ option {
   margin-right: 8px;
 }
 
+.main-skipBackButton-button:hover, .main-skipForwardButton-button:hover {
+  background-color: hsla(0,0%,100%,.7) !important;
+}
+
+.main-skipBackButton-button:focus:not(:focus-visible):not(:hover), .main-skipForwardButton-button:focus:not(:focus-visible):not(:hover) {
+  background-color: var(--spice-text) !important;
+}
+
+.main-skipBackButton-button:active, .main-skipForwardButton-button:active {
+  transform: scale(.89);
+  transition: none;
+}
+
 .main-playPauseButton-button,
 .player-controls__buttons button:not(.main-playPauseButton-button) {
   --button-size: 28px !important;


### PR DESCRIPTION
Just added a little change that makes the skip forward/backward buttons feel more like a button. (see GIF below)
![buttons](https://user-images.githubusercontent.com/51394649/181440275-1f91cd73-b8a3-400b-b93b-9120bcbe9c8d.gif)