### PR TITLE
Invoke `bash` instead of `sh` for Linux installation (#121)

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Invoke-WebRequest -UseBasicParsing "https://raw.githubusercontent.com/nimsandu/s
 ### Linux/macOS (Bash)
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/nimsandu/spicetify-bloom/main/install.sh | sh
+curl -fsSL https://raw.githubusercontent.com/nimsandu/spicetify-bloom/main/install.sh | bash
 ```
 
 ...or if you don't want to use shell commands, you can download the installation scripts within the repository.

--- a/install.sh
+++ b/install.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 set -e
 


### PR DESCRIPTION
See mentioned issue for more info.

Test: Before and after this commit. Before this commit will return illegal option for switch `-s` given to command `read`. After this commit will work all fine.