### PR TITLE
fix:play button not showing at launch

### DIFF
--- a/user.css
+++ b/user.css
@@ -1888,8 +1888,8 @@ option {
 }
 
 .main-playButton-PlayButton>button {
- width: var(--size);
- height: var(--size);
+ width: 40px;
+ height: 40px;
 }
 
 .main-playButton-PlayButton>button>span {


### PR DESCRIPTION
i changed the button size from `var(--size)` to `40px` instead. 

for some reason `var(--size)` are not existed when you launch spotify. it shown after you open artist page. idk why but here's the fix
