### PR TITLE
fix infinite waitForElement running when not found element

### DIFF
--- a/bloom.js
+++ b/bloom.js
@@ -5,7 +5,7 @@
     if (queries.every(a => a)) {
       func();
     } else if (timeout > 0) {
-      setTimeout(waitForElement, 300, els, func, timeout--);
+      setTimeout(waitForElement, 300, els, func, timeout-1);
     }
   }
   waitForElement([


### PR DESCRIPTION
You can check yourself adding smth like ```console.log("Waiting for ", els, "time remaining: ", timeout)``` after ```else if (timeout > 0) {```
```timeout--``` doesn't work, resulting in an infinite loop