### PR TITLE
fix(install-sh): some ocasional bugs

### DIFF
--- a/install/install.sh
+++ b/install/install.sh
@@ -29,6 +29,16 @@ if [ -z "$(which spicetify)" ]; then
     exit 1
 fi
 
+if [ -z "$(which mktemp)" ]; then
+    printf "\x1B[1;31m"
+    echo "mktemp isn't installed or doesn't exist in your PATH."
+    echo "Mktemp is used to generate temporal paths to place the files, and so it's an essential."
+    echo -e "\nAbort!"
+    printf "\x1B[0m"
+    # b/126
+    exit 5
+fi
+
 echo "Beginning installation of spicetify-bloom"
 echo "https://github.com/nimsandu/spicetify-bloom"
 

--- a/install/install.sh
+++ b/install/install.sh
@@ -55,7 +55,7 @@ curl --fail --location --progress-bar "$zipUri" --output "$zipSavePath"
 
 # Extract theme from .zip file
 echo "Extracting..."
-unzip -q "$zipSavePath" -d "$zipExtractPath"
+unzip -oq "$zipSavePath" -d "$zipExtractPath" < /dev/tty
 mv "$zipExtractPath/spicetify-bloom-main/src/" "$themePath"
 
 # Delete .zip file

--- a/install/install.sh
+++ b/install/install.sh
@@ -3,23 +3,27 @@
 set -e
 
 if [ -z "$(which spotify)" ]; then
+    printf "\x1B[1;31m"
     echo "Spotify isn't installed or doesn't exist in your PATH."
     echo "Bloom is a Spotify theme, and so it's an essential."
     echo "Please install Spotify (https://spotify.com/download) and run this script again to continue."
     echo "If Spotify is already installed, add it to your PATH variable and rerun this script."
     echo "Example command for adding to PATH: export PATH=~/spotify:\$PATH"
     echo -e "\nAbort!"
+    printf "\x1B[0m"
     # b/126
     exit 3
 fi
 
 if [ -z "$(which spicetify)" ]; then
+    printf "\x1B[1;31m"
     echo "Spicetify isn't installed or doesn't exist in your PATH."
     echo "Bloom relies on it to work properly."
     echo "Please install Spicetify (https://spicetify.app) and run this script again to continue."
     echo "If Spicetify is already installed, add it to your PATH variable and rerun this script."
     echo "Example command for adding to PATH: export PATH=/opt/spicetify:\$PATH"
     echo -e "\nAbort!"
+    printf "\x1B[0m"
     # Exit approach seems to work better.
     # b/126
     exit 1

--- a/install/install.sh
+++ b/install/install.sh
@@ -41,7 +41,8 @@ fi
 
 # Remove old extension
 spicetify config extensions bloom.js- -q
-if [[ -e "$spicePath/Extensions/bloom.js" ]]; then
+extensionPath="$spicePath/Extensions/bloom.js"
+if [[ -e "$extensionPath" || -h "$extensionPath" ]]; then
   rm "$spicePath/Extensions/bloom.js"
 fi
 

--- a/install/install.sh
+++ b/install/install.sh
@@ -48,18 +48,19 @@ fi
 
 # Download latest master
 zipUri="https://github.com/nimsandu/spicetify-bloom/archive/refs/heads/master.zip"
-zipSavePath="/tmp/bloom-main.zip"
+zipSavePath=`mktemp`
+zipExtractPath=`mktemp -d`
 echo "Downloading bloom-spicetify latest master..."
 curl --fail --location --progress-bar "$zipUri" --output "$zipSavePath"
 
 # Extract theme from .zip file
 echo "Extracting..."
-unzip -q "$zipSavePath" -d "$spicePath"
-mv "$spicePath/spicetify-bloom-main/src/" "$themePath"
+unzip -q "$zipSavePath" -d "$zipExtractPath"
+mv "$zipExtractPath/spicetify-bloom-main/src/" "$themePath"
 
 # Delete .zip file
 echo "Deleting zip file..."
-rm "$zipSavePath"
+rm "$zipSavePath" -rf "$zipExtractPath"
 
 # Apply the theme with spicetify config calls
 spicetify config current_theme bloom


### PR DESCRIPTION
Fixed the following "bugs":
- `bloom.js` not being removed if it's a broken symlink
- extracting the zip when `$spicePath/spicetify-bloom-main` existed crashed the whole install when the unzip command tried to prompt the user if to replace files

What I did:
- check if `bloom.js` is also a symlink
- place all files in the unzipping process in a temporal location to avoid existing directory
- force unzip to replace files
- give unzip access to user prompt in case it asks anything else
- I also colored main errors in bold red