### PR TITLE
Adds color scheme based on the Zorin OS dark green colors

### DIFF
--- a/src/color.ini
+++ b/src/color.ini
@@ -139,3 +139,27 @@ accent             = 35b8f3
 layer-shadow       = 1d1d1d
 contour            = 0c0c0c
 
+[zdarkgreen]
+text               =BBF1DD
+subtext            =6b8a7f
+alt-text           =6b8a7f
+main               =1B2421
+sidebar            =1B2421
+player             =101411
+player-border      =33433d
+player-bar-shadow  =BBF1DD
+player-bar-bg      =323336
+card               =101411
+shadow             =101411
+selected-row       =33433D
+button             =28c48b
+button-active      =00ac6f
+button-disabled    =33433D
+tab-active         =33433D
+notification       =6b8a7f
+notification-error =d43353
+misc               =6b8a7f
+not-selected       =6b8a7f
+accent             =BBF1DD
+layer-shadow       =1B2421
+contour            =1B2421


### PR DESCRIPTION
In color.ini, I called it `zdarkgreen` but feel free to name it whatever makes most sense to you.