### PR TITLE
fix(install.sh): error deleting .zip file

### DIFF
--- a/install/install.sh
+++ b/install/install.sh
@@ -80,7 +80,7 @@ mv "$zipExtractPath/spicetify-bloom-main/src/" "$themePath"
 
 # Delete .zip file
 echo "Deleting zip file..."
-rm "$zipSavePath" -rf "$zipExtractPath"
+rm -rf "$zipSavePath" "$zipExtractPath"
 
 # Apply the theme with spicetify config calls
 spicetify config current_theme bloom


### PR DESCRIPTION
I believe there's an error in the script, as options to `rm` command must be placed right after `rm` itself.

I managed to solve this error with the proposed patch and got the script to run 'til the end on my machine (macOS 13.4.1, Spotify 1.2.15, Spicetify v2.21.0)