### PR TITLE
Fixed typo in the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ Use this guide to install if you're having trouble using the shell commands/inst
 5. Open a terminal/command prompt window and type the following commands:
 
    ```shell
-    spicetify config current_theme Bloom color_scheme dark
+    spicetify config current_theme bloom color_scheme dark
     spicetify config inject_css 1 replace_colors 1 overwrite_assets 1 inject_theme_js 1
     spicetify apply
     ```
@@ -113,8 +113,8 @@ If you installed Bloom from Marketplace you can change the color scheme on its p
 
 ### Accent Color
 
-1. Navigate to the Spicetify's `Themes` directory. Use `spicetify path userdata` command to get the path.
-2. Open `Bloom` folder.
+1. Navigate to the Spicetify's `themes` directory. Use `spicetify path userdata` command to get the path.
+2. Open `bloom` folder.
 3. Edit your current color scheme in the `color.ini` file.
 4. Use the `spicetify apply` command.
 


### PR DESCRIPTION
In the instructions in the README.md:
```
 spicetify config current_theme Bloom color_scheme dark
 spicetify config inject_css 1 replace_colors 1 overwrite_assets 1 inject_theme_js 1
 spicetify apply
```
 
The actual folder is named 'bloom' not 'Bloom', which caused the install instructions to not work